### PR TITLE
[리팩터링] application 패키지에 있는 VO object들 domain 패키지로 이동

### DIFF
--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/controller/product/ProductController.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/controller/product/ProductController.kt
@@ -1,15 +1,15 @@
 package com.juloungjuloung.juju.controller.product
 
+import com.juloungjuloung.juju.application.facade.product.ProductServiceFacade
 import com.juloungjuloung.juju.dto.product.request.SaveProductRequest
 import com.juloungjuloung.juju.dto.product.request.UpdateProductRequest
 import com.juloungjuloung.juju.dto.product.response.ProductResponse
 import com.juloungjuloung.juju.enums.ProductTypeEnum
-import com.juloungjuloung.juju.objectmapper.ProductRequestMapper.Companion.toDomain
-import com.juloungjuloung.juju.objectmapper.ProductRequestMapper.Companion.toUpdateDto
+import com.juloungjuloung.juju.objectmapper.ProductRequestMapper.Companion.toSaveVO
+import com.juloungjuloung.juju.objectmapper.ProductRequestMapper.Companion.toUpdateVO
 import com.juloungjuloung.juju.objectmapper.ProductResponseMapper.Companion.toResponse
 import com.juloungjuloung.juju.response.ApiResponse
 import com.juloungjuloung.juju.response.ApiResponse.Companion.success
-import com.juloungjuloung.juju.service.facade.product.ProductServiceFacade
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
@@ -45,9 +45,7 @@ class ProductController(
         @RequestBody saveProductRequest: SaveProductRequest
     ): ApiResponse<Long> {
         return success(
-            productFacade.saveProduct(
-                toDomain(saveProductRequest)
-            )
+            productFacade.saveProduct(toSaveVO(saveProductRequest))
         )
     }
 
@@ -57,7 +55,7 @@ class ProductController(
         updateProductRequest: UpdateProductRequest
     ): ApiResponse<Long> {
         return success(
-            productFacade.updateProduct(toUpdateDto(updateProductRequest))
+            productFacade.updateProduct(toUpdateVO(updateProductRequest))
         )
     }
 }

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/request/SaveProductRequest.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/request/SaveProductRequest.kt
@@ -1,86 +1,44 @@
 package com.juloungjuloung.juju.dto.product.request
 
-import com.juloungjuloung.juju.domain.product.impl.Bracelet
-import com.juloungjuloung.juju.domain.product.impl.Earring
-import com.juloungjuloung.juju.domain.product.impl.Necklace
-import com.juloungjuloung.juju.domain.product.impl.Ring
+import com.juloungjuloung.juju.enums.ProductImageEnum.PRODUCT_DEFAULT_IMAGE
 import com.juloungjuloung.juju.enums.ProductTypeEnum
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.PositiveOrZero
 
 data class SaveProductRequest(
+    @NotNull
     val productType: ProductTypeEnum,
+
+    @NotBlank
     val name: String,
+
+    @PositiveOrZero
     val price: Long,
+
+    @PositiveOrZero
     val weightByMilliGram: Long,
+
+    val thumbnailImage: String = PRODUCT_DEFAULT_IMAGE.url,
+
     val isDiamond: Boolean,
+
+    @PositiveOrZero
     val totalDiamondCaratX100: Int,
 
-    val additionalBraceletRequest: SaveBraceletAdditionalRequest?,
-    val additionalNecklaceRequest: SaveNecklaceAdditionalRequest?
+    val isDisplay: Boolean,
+
+    val saveBraceletAdditionalRequest: SaveBraceletAdditionalRequest?,
+    val saveNecklaceAdditionalRequest: SaveNecklaceAdditionalRequest?
 ) {
     init {
         if (ProductTypeEnum.BRACELET == productType) {
-            requireNotNull(additionalBraceletRequest)
+            requireNotNull(saveBraceletAdditionalRequest)
         }
 
         if (ProductTypeEnum.NECKLACE == productType) {
-            requireNotNull(additionalNecklaceRequest)
+            requireNotNull(saveNecklaceAdditionalRequest)
         }
-    }
-
-    fun toBracelet(): Bracelet {
-        return Bracelet(
-            name = name,
-            productCode = "dd", // TODO : productCode
-            price = price,
-            weightByMilliGram = weightByMilliGram,
-            thumbnailImage = null,
-            isDiamond = isDiamond,
-            totalDiamondCaratX100 = totalDiamondCaratX100,
-            isDisplay = false,
-            maximumLength = additionalBraceletRequest!!.maximumLength,
-            minimumLength = additionalBraceletRequest.minimumLength
-        )
-    }
-
-    fun toEarring(): Earring {
-        return Earring(
-            name = name,
-            productCode = "dd", // TODO : productCode
-            price = price,
-            weightByMilliGram = weightByMilliGram,
-            thumbnailImage = null,
-            isDiamond = isDiamond,
-            totalDiamondCaratX100 = totalDiamondCaratX100,
-            isDisplay = false
-        )
-    }
-
-    fun toNecklace(): Necklace {
-        return Necklace(
-            name = name,
-            productCode = "dd", // TODO : productCode
-            price = price,
-            weightByMilliGram = weightByMilliGram,
-            thumbnailImage = null,
-            isDiamond = isDiamond,
-            totalDiamondCaratX100 = totalDiamondCaratX100,
-            isDisplay = false,
-            maximumLength = additionalNecklaceRequest!!.maximumLength,
-            minimumLength = additionalNecklaceRequest.minimumLength
-        )
-    }
-
-    fun toRing(): Ring {
-        return Ring(
-            name = name,
-            productCode = "dd", // TODO : productCode
-            price = price,
-            weightByMilliGram = weightByMilliGram,
-            thumbnailImage = null,
-            isDiamond = isDiamond,
-            totalDiamondCaratX100 = totalDiamondCaratX100,
-            isDisplay = false
-        )
     }
 }
 

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/request/UpdateProductRequest.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/request/UpdateProductRequest.kt
@@ -1,19 +1,25 @@
 package com.juloungjuloung.juju.dto.product.request
 
 import com.juloungjuloung.juju.enums.ProductTypeEnum
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
 
 data class UpdateProductRequest(
+    @Positive
     val id: Long,
+
+    @NotNull
     val productType: ProductTypeEnum,
     val name: String?,
     val price: Long?,
     val weightByMilliGram: Long?,
+    val thumbnailImage: String?,
     val isDiamond: Boolean?,
     val totalDiamondCaratX100: Int?,
     val isDisplay: Boolean?,
 
-    val additionalBraceletRequest: UpdateBraceletAdditionalRequest?,
-    val additionalNecklaceAdditionalRequest: UpdateNecklaceAdditionalRequest?
+    val updateBraceletAdditionalRequest: UpdateBraceletAdditionalRequest?,
+    val updateNecklaceAdditionalRequest: UpdateNecklaceAdditionalRequest?
 )
 
 data class UpdateBraceletAdditionalRequest(

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/ProductResponse.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/ProductResponse.kt
@@ -4,7 +4,7 @@ import com.juloungjuloung.juju.domain.product.Product
 import java.time.LocalDateTime
 
 open class ProductResponse(
-    val type: String,
+    val productType: String,
     val name: String,
     val productCode: String,
     val price: Long,
@@ -21,7 +21,7 @@ open class ProductResponse(
         fun of(product: Product): ProductResponse {
             return ProductResponse(
                 id = product.id,
-                type = product.type.name,
+                productType = product.productType.name,
                 name = product.name,
                 productCode = product.productCode,
                 price = product.price,

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/impl/BraceletResponse.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/impl/BraceletResponse.kt
@@ -22,7 +22,7 @@ class BraceletResponse(
     val minimumLength: Int
 ) : ProductResponse(
     id = id,
-    type = type,
+    productType = type,
     name = name,
     productCode = productCode,
     price = price,
@@ -38,7 +38,7 @@ class BraceletResponse(
         fun of(result: Bracelet): BraceletResponse {
             return BraceletResponse(
                 id = result.id,
-                type = result.type.name,
+                type = result.productType.name,
                 name = result.name,
                 productCode = result.productCode,
                 price = result.price,

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/impl/EarringResponse.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/impl/EarringResponse.kt
@@ -19,7 +19,7 @@ class EarringResponse(
     updatedAt: LocalDateTime
 ) : ProductResponse(
     id = id,
-    type = type,
+    productType = type,
     name = name,
     productCode = productCode,
     price = price,
@@ -35,7 +35,7 @@ class EarringResponse(
         fun of(result: Earring): EarringResponse {
             return EarringResponse(
                 id = result.id,
-                type = result.type.name,
+                type = result.productType.name,
                 name = result.name,
                 productCode = result.productCode,
                 price = result.price,

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/impl/NecklaceResponse.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/impl/NecklaceResponse.kt
@@ -22,7 +22,7 @@ class NecklaceResponse(
     val minimumLength: Int
 ) : ProductResponse(
     id = id,
-    type = type,
+    productType = type,
     name = name,
     productCode = productCode,
     price = price,
@@ -38,7 +38,7 @@ class NecklaceResponse(
         fun of(result: Necklace): NecklaceResponse {
             return NecklaceResponse(
                 id = result.id,
-                type = result.type.name,
+                type = result.productType.name,
                 name = result.name,
                 productCode = result.productCode,
                 price = result.price,

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/impl/RingResponse.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/dto/product/response/impl/RingResponse.kt
@@ -19,7 +19,7 @@ class RingResponse(
     updatedAt: LocalDateTime
 ) : ProductResponse(
     id = id,
-    type = type,
+    productType = type,
     name = name,
     productCode = productCode,
     price = price,
@@ -35,7 +35,7 @@ class RingResponse(
         fun of(result: Ring): RingResponse {
             return RingResponse(
                 id = result.id,
-                type = result.type.name,
+                type = result.productType.name,
                 name = result.name,
                 productCode = result.productCode,
                 price = result.price,

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/objectmapper/ProductRequestMapper.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/objectmapper/ProductRequestMapper.kt
@@ -1,44 +1,72 @@
 package com.juloungjuloung.juju.objectmapper
 
-import com.juloungjuloung.juju.application.dto.UpdateBraceletAdditionalDto
-import com.juloungjuloung.juju.application.dto.UpdateNecklaceAdditionalDto
-import com.juloungjuloung.juju.application.dto.UpdateProductDto
-import com.juloungjuloung.juju.domain.product.Product
+import com.juloungjuloung.juju.domain.product.vo.SaveBraceletAdditionalVO
+import com.juloungjuloung.juju.domain.product.vo.SaveNecklaceAdditionalVO
+import com.juloungjuloung.juju.domain.product.vo.SaveProductVO
+import com.juloungjuloung.juju.domain.product.vo.UpdateBraceletAdditionalVO
+import com.juloungjuloung.juju.domain.product.vo.UpdateNecklaceAdditionalVO
+import com.juloungjuloung.juju.domain.product.vo.UpdateProductVO
+import com.juloungjuloung.juju.dto.product.request.SaveBraceletAdditionalRequest
+import com.juloungjuloung.juju.dto.product.request.SaveNecklaceAdditionalRequest
 import com.juloungjuloung.juju.dto.product.request.SaveProductRequest
 import com.juloungjuloung.juju.dto.product.request.UpdateBraceletAdditionalRequest
 import com.juloungjuloung.juju.dto.product.request.UpdateNecklaceAdditionalRequest
 import com.juloungjuloung.juju.dto.product.request.UpdateProductRequest
-import com.juloungjuloung.juju.enums.ProductTypeEnum
 
 class ProductRequestMapper {
     companion object {
-        fun toDomain(request: SaveProductRequest): Product {
-            return when (request.productType) {
-                ProductTypeEnum.BRACELET -> request.toBracelet()
-                ProductTypeEnum.EARRING -> request.toEarring()
-                ProductTypeEnum.NECKLACE -> request.toNecklace()
-                ProductTypeEnum.RING -> request.toRing()
-            }
+        fun toSaveVO(request: SaveProductRequest): SaveProductVO {
+            return SaveProductVO(
+                productType = request.productType,
+                name = request.name,
+                price = request.price,
+                weightByMilliGram = request.weightByMilliGram,
+                thumbnailImage = request.thumbnailImage,
+                isDiamond = request.isDiamond,
+                totalDiamondCaratX100 = request.totalDiamondCaratX100,
+                isDisplay = request.isDisplay,
+                saveBraceletAdditionalVO = request.saveBraceletAdditionalRequest?.let {
+                    toSaveBraceletAdditionalVO(it)
+                },
+                saveNecklaceAdditionalVO = request.saveNecklaceAdditionalRequest?.let {
+                    toSaveNecklaceAdditionalVO(it)
+                }
+            )
         }
 
-        fun toUpdateDto(request: UpdateProductRequest): UpdateProductDto {
-            return UpdateProductDto(
+        private fun toSaveBraceletAdditionalVO(request: SaveBraceletAdditionalRequest): SaveBraceletAdditionalVO {
+            return SaveBraceletAdditionalVO(
+                maximumLength = request.maximumLength,
+                minimumLength = request.minimumLength
+            )
+        }
+
+        private fun toSaveNecklaceAdditionalVO(request: SaveNecklaceAdditionalRequest): SaveNecklaceAdditionalVO {
+            return SaveNecklaceAdditionalVO(
+                maximumLength = request.maximumLength,
+                minimumLength = request.minimumLength
+            )
+        }
+
+        fun toUpdateVO(request: UpdateProductRequest): UpdateProductVO {
+            return UpdateProductVO(
                 id = request.id,
                 productType = request.productType,
                 name = request.name,
                 price = request.price,
                 weightByMilliGram = request.weightByMilliGram,
+                thumbnailImage = request.thumbnailImage,
                 isDiamond = request.isDiamond,
                 totalDiamondCaratX100 = request.totalDiamondCaratX100,
                 isDisplay = request.isDisplay,
-                additionalBraceletRequest = toNestedDto(request.additionalBraceletRequest),
-                additionalNecklaceAdditionalRequest = toNestedDto(request.additionalNecklaceAdditionalRequest)
+                additionalBraceletVO = toUpdateBraceletVO(request.updateBraceletAdditionalRequest),
+                additionalNecklaceVO = toUpdateNecklaceVO(request.updateNecklaceAdditionalRequest)
             )
         }
 
-        private fun toNestedDto(request: UpdateBraceletAdditionalRequest?): UpdateBraceletAdditionalDto? {
+        private fun toUpdateBraceletVO(request: UpdateBraceletAdditionalRequest?): UpdateBraceletAdditionalVO? {
             request?.let {
-                return UpdateBraceletAdditionalDto(
+                return UpdateBraceletAdditionalVO(
                     maximumLength = request.maximumLength,
                     minimumLength = request.minimumLength
                 )
@@ -47,9 +75,9 @@ class ProductRequestMapper {
             return null
         }
 
-        private fun toNestedDto(request: UpdateNecklaceAdditionalRequest?): UpdateNecklaceAdditionalDto? {
+        private fun toUpdateNecklaceVO(request: UpdateNecklaceAdditionalRequest?): UpdateNecklaceAdditionalVO? {
             request?.let {
-                return UpdateNecklaceAdditionalDto(
+                return UpdateNecklaceAdditionalVO(
                     maximumLength = request.maximumLength,
                     minimumLength = request.minimumLength
                 )

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/application/facade/product/ProductServiceFacade.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/application/facade/product/ProductServiceFacade.kt
@@ -1,8 +1,9 @@
-package com.juloungjuloung.juju.service.facade.product
+package com.juloungjuloung.juju.application.facade.product
 
-import com.juloungjuloung.juju.application.dto.UpdateProductDto
 import com.juloungjuloung.juju.application.factory.ProductServiceFactory
 import com.juloungjuloung.juju.domain.product.Product
+import com.juloungjuloung.juju.domain.product.vo.SaveProductVO
+import com.juloungjuloung.juju.domain.product.vo.UpdateProductVO
 import com.juloungjuloung.juju.enums.ProductTypeEnum
 import org.springframework.stereotype.Service
 
@@ -16,17 +17,17 @@ class ProductServiceFacade(
         return service.read(page, size)
     }
 
-    fun saveProduct(product: Product): Long {
-        val service = productServiceFactory.get(product.type)
+    fun saveProduct(saveProductVO: SaveProductVO): Long {
+        val service = productServiceFactory.get(saveProductVO.productType)
 
-        return service.save(product)
+        return service.save(saveProductVO.toDomain())
     }
 
-    fun updateProduct(updateProductDto: UpdateProductDto): Long {
-        val service = productServiceFactory.get(updateProductDto.productType)
+    fun updateProduct(updateProductVO: UpdateProductVO): Long {
+        val service = productServiceFactory.get(updateProductVO.productType)
 
-        val findProduct = service.readById(updateProductDto.id)
-        findProduct.update(updateProductDto)
+        val findProduct = service.readById(updateProductVO.id)
+        findProduct.update(updateProductVO)
 
         return service.update(findProduct)
     }

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/Product.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/Product.kt
@@ -1,12 +1,12 @@
 package com.juloungjuloung.juju.domain.product
 
-import com.juloungjuloung.juju.application.dto.UpdateProductDto
+import com.juloungjuloung.juju.domain.product.vo.UpdateProductVO
 import com.juloungjuloung.juju.enums.ProductTypeEnum
 import java.time.LocalDateTime
 
 open class Product(
     val id: Long = 0L,
-    val type: ProductTypeEnum,
+    val productType: ProductTypeEnum,
     var name: String,
     val productCode: String,
     var price: Long,
@@ -32,16 +32,17 @@ open class Product(
     }
 
     open fun update(
-        updateProductDto: UpdateProductDto
+        updateProductVO: UpdateProductVO
     ) {
-        updateProductDto.name?.let { this.name = updateProductDto.name }
-        updateProductDto.price?.let { this.price = updateProductDto.price }
-        updateProductDto.weightByMilliGram?.let { this.weightByMilliGram = updateProductDto.weightByMilliGram }
-        updateProductDto.isDiamond?.let { this.isDiamond = updateProductDto.isDiamond }
-        updateProductDto.totalDiamondCaratX100?.let {
-            this.totalDiamondCaratX100 = updateProductDto.totalDiamondCaratX100
+        updateProductVO.name?.let { this.name = updateProductVO.name }
+        updateProductVO.price?.let { this.price = updateProductVO.price }
+        updateProductVO.weightByMilliGram?.let { this.weightByMilliGram = updateProductVO.weightByMilliGram }
+        updateProductVO.thumbnailImage?.let { this.thumbnailImage = updateProductVO.thumbnailImage }
+        updateProductVO.isDiamond?.let { this.isDiamond = updateProductVO.isDiamond }
+        updateProductVO.totalDiamondCaratX100?.let {
+            this.totalDiamondCaratX100 = updateProductVO.totalDiamondCaratX100
         }
-        updateProductDto.isDisplay?.let { this.isDisplay = updateProductDto.isDisplay }
+        updateProductVO.isDisplay?.let { this.isDisplay = updateProductVO.isDisplay }
 
         requireProperties()
     }

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/impl/Bracelet.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/impl/Bracelet.kt
@@ -1,7 +1,7 @@
 package com.juloungjuloung.juju.domain.product.impl
 
-import com.juloungjuloung.juju.application.dto.UpdateProductDto
 import com.juloungjuloung.juju.domain.product.Product
+import com.juloungjuloung.juju.domain.product.vo.UpdateProductVO
 import com.juloungjuloung.juju.enums.ProductTypeEnum
 import java.time.LocalDateTime
 
@@ -22,7 +22,7 @@ class Bracelet(
     var minimumLength: Int
 ) : Product(
     id = id,
-    type = ProductTypeEnum.BRACELET,
+    productType = ProductTypeEnum.BRACELET,
     name = name,
     productCode = productCode,
     price = price,
@@ -39,12 +39,12 @@ class Bracelet(
         require(maximumLength > minimumLength)
     }
 
-    override fun update(updateProductDto: UpdateProductDto) {
-        super.update(updateProductDto)
+    override fun update(updateProductVO: UpdateProductVO) {
+        super.update(updateProductVO)
 
-        updateProductDto.additionalBraceletRequest?.let {
-            this.maximumLength = updateProductDto.additionalBraceletRequest.maximumLength
-            this.minimumLength = updateProductDto.additionalBraceletRequest.minimumLength
+        updateProductVO.additionalBraceletVO?.let {
+            this.maximumLength = updateProductVO.additionalBraceletVO.maximumLength
+            this.minimumLength = updateProductVO.additionalBraceletVO.minimumLength
         }
     }
 }

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/impl/Earring.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/impl/Earring.kt
@@ -18,7 +18,7 @@ class Earring(
     updatedAt: LocalDateTime = LocalDateTime.now()
 ) : Product(
     id = id,
-    type = ProductTypeEnum.EARRING,
+    productType = ProductTypeEnum.EARRING,
     name = name,
     productCode = productCode,
     price = price,

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/impl/Necklace.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/impl/Necklace.kt
@@ -1,7 +1,7 @@
 package com.juloungjuloung.juju.domain.product.impl
 
-import com.juloungjuloung.juju.application.dto.UpdateProductDto
 import com.juloungjuloung.juju.domain.product.Product
+import com.juloungjuloung.juju.domain.product.vo.UpdateProductVO
 import com.juloungjuloung.juju.enums.ProductTypeEnum
 import java.time.LocalDateTime
 
@@ -22,7 +22,7 @@ class Necklace(
     var minimumLength: Int
 ) : Product(
     id = id,
-    type = ProductTypeEnum.NECKLACE,
+    productType = ProductTypeEnum.NECKLACE,
     name = name,
     productCode = productCode,
     price = price,
@@ -39,12 +39,12 @@ class Necklace(
         require(maximumLength > minimumLength)
     }
 
-    override fun update(updateProductDto: UpdateProductDto) {
-        super.update(updateProductDto)
+    override fun update(updateProductVO: UpdateProductVO) {
+        super.update(updateProductVO)
 
-        updateProductDto.additionalNecklaceAdditionalRequest?.let {
-            this.maximumLength = updateProductDto.additionalNecklaceAdditionalRequest.maximumLength
-            this.minimumLength = updateProductDto.additionalNecklaceAdditionalRequest.minimumLength
+        updateProductVO.additionalNecklaceVO?.let {
+            this.maximumLength = updateProductVO.additionalNecklaceVO.maximumLength
+            this.minimumLength = updateProductVO.additionalNecklaceVO.minimumLength
         }
     }
 }

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/impl/Ring.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/impl/Ring.kt
@@ -18,7 +18,7 @@ class Ring(
     updatedAt: LocalDateTime = LocalDateTime.now()
 ) : Product(
     id = id,
-    type = ProductTypeEnum.NECKLACE,
+    productType = ProductTypeEnum.NECKLACE,
     name = name,
     productCode = productCode,
     price = price,

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/vo/SaveProductVO.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/vo/SaveProductVO.kt
@@ -1,0 +1,101 @@
+package com.juloungjuloung.juju.domain.product.vo
+
+import com.juloungjuloung.juju.domain.product.Product
+import com.juloungjuloung.juju.domain.product.impl.Bracelet
+import com.juloungjuloung.juju.domain.product.impl.Earring
+import com.juloungjuloung.juju.domain.product.impl.Necklace
+import com.juloungjuloung.juju.domain.product.impl.Ring
+import com.juloungjuloung.juju.enums.ProductTypeEnum
+import com.juloungjuloung.juju.enums.ProductTypeEnum.BRACELET
+import com.juloungjuloung.juju.enums.ProductTypeEnum.EARRING
+import com.juloungjuloung.juju.enums.ProductTypeEnum.NECKLACE
+import com.juloungjuloung.juju.enums.ProductTypeEnum.RING
+
+data class SaveProductVO(
+    val productType: ProductTypeEnum,
+    val name: String,
+    val price: Long,
+    val weightByMilliGram: Long,
+    val thumbnailImage: String,
+    val isDiamond: Boolean,
+    val totalDiamondCaratX100: Int,
+    val isDisplay: Boolean,
+
+    val saveBraceletAdditionalVO: SaveBraceletAdditionalVO?,
+    val saveNecklaceAdditionalVO: SaveNecklaceAdditionalVO?
+) {
+    fun toDomain(): Product {
+        return when (productType) {
+            BRACELET -> toBracelet()
+            EARRING -> toEarring()
+            NECKLACE -> toNecklace()
+            RING -> toRing()
+        }
+    }
+
+    private fun toBracelet(): Bracelet {
+        return Bracelet(
+            name = name,
+            productCode = "dd", // TODO : productCode
+            price = price,
+            weightByMilliGram = weightByMilliGram,
+            thumbnailImage = thumbnailImage,
+            isDiamond = isDiamond,
+            totalDiamondCaratX100 = totalDiamondCaratX100,
+            isDisplay = isDisplay,
+            maximumLength = saveBraceletAdditionalVO!!.maximumLength,
+            minimumLength = saveBraceletAdditionalVO.minimumLength
+        )
+    }
+
+    private fun toEarring(): Earring {
+        return Earring(
+            name = name,
+            productCode = "dd", // TODO : productCode
+            price = price,
+            weightByMilliGram = weightByMilliGram,
+            thumbnailImage = thumbnailImage,
+            isDiamond = isDiamond,
+            totalDiamondCaratX100 = totalDiamondCaratX100,
+            isDisplay = isDisplay
+        )
+    }
+
+    private fun toNecklace(): Necklace {
+        return Necklace(
+            name = name,
+            productCode = "dd", // TODO : productCode
+            price = price,
+            weightByMilliGram = weightByMilliGram,
+            thumbnailImage = thumbnailImage,
+            isDiamond = isDiamond,
+            totalDiamondCaratX100 = totalDiamondCaratX100,
+            isDisplay = isDisplay,
+            maximumLength = saveNecklaceAdditionalVO!!.maximumLength,
+            minimumLength = saveNecklaceAdditionalVO.minimumLength
+        )
+    }
+
+    private fun toRing(): Ring {
+        return Ring(
+            name = name,
+            productCode = "dd", // TODO : productCode
+            price = price,
+            weightByMilliGram = weightByMilliGram,
+            thumbnailImage = thumbnailImage,
+            isDiamond = isDiamond,
+            totalDiamondCaratX100 = totalDiamondCaratX100,
+            isDisplay = isDisplay
+        )
+    }
+}
+
+data class SaveBraceletAdditionalVO(
+    val maximumLength: Int,
+    val minimumLength: Int
+)
+
+data class SaveNecklaceAdditionalVO(
+    val maximumLength: Int,
+    val minimumLength: Int
+)

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/vo/UpdateProductVO.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/vo/UpdateProductVO.kt
@@ -1,27 +1,28 @@
-package com.juloungjuloung.juju.application.dto
+package com.juloungjuloung.juju.domain.product.vo
 
 import com.juloungjuloung.juju.enums.ProductTypeEnum
 
-data class UpdateProductDto(
+data class UpdateProductVO(
     val id: Long,
     val productType: ProductTypeEnum,
     val name: String? = null,
     val price: Long? = null,
     val weightByMilliGram: Long? = null,
+    val thumbnailImage: String?,
     val isDiamond: Boolean? = null,
     val totalDiamondCaratX100: Int? = null,
     val isDisplay: Boolean? = null,
 
-    val additionalBraceletRequest: UpdateBraceletAdditionalDto? = null,
-    val additionalNecklaceAdditionalRequest: UpdateNecklaceAdditionalDto? = null
+    val additionalBraceletVO: UpdateBraceletAdditionalVO? = null,
+    val additionalNecklaceVO: UpdateNecklaceAdditionalVO? = null
 )
 
-data class UpdateBraceletAdditionalDto(
+data class UpdateBraceletAdditionalVO(
     val maximumLength: Int,
     val minimumLength: Int
 )
 
-data class UpdateNecklaceAdditionalDto(
+data class UpdateNecklaceAdditionalVO(
     val maximumLength: Int,
     val minimumLength: Int
 )

--- a/juju-core/src/test/kotlin/com/juloungjuloung/juju/application/facade/product/ProductServiceFacadeTest.kt
+++ b/juju-core/src/test/kotlin/com/juloungjuloung/juju/application/facade/product/ProductServiceFacadeTest.kt
@@ -2,9 +2,8 @@ package com.juloungjuloung.juju.application.facade.product
 
 import com.juloungjuloung.juju.application.factory.ProductServiceFactory
 import com.juloungjuloung.juju.domain.product.service.impl.RingService
+import com.juloungjuloung.juju.domain.saveRingVO
 import com.juloungjuloung.juju.enums.ProductTypeEnum
-import com.juloungjuloung.juju.ringFixture
-import com.juloungjuloung.juju.service.facade.product.ProductServiceFacade
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
@@ -22,7 +21,7 @@ class ProductServiceFacadeTest : BehaviorSpec({
             every { productServiceFactory.get(any()) } returns ringService
 
             productServiceFacade.readProducts(ProductTypeEnum.RING, 0, 10)
-            productServiceFacade.saveProduct(ringFixture())
+            productServiceFacade.saveProduct(saveRingVO())
 
             Then("해당 서비스에게 요청을 위임한다") {
                 verify { ringService.read(any(), any()) }

--- a/juju-core/src/testFixtures/kotlin/com/juloungjuloung/juju/TestFixturesConfig.kt
+++ b/juju-core/src/testFixtures/kotlin/com/juloungjuloung/juju/TestFixturesConfig.kt
@@ -1,0 +1,8 @@
+package com.juloungjuloung.juju
+
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
+
+val fixtureMonkey: FixtureMonkey = FixtureMonkey.builder()
+    .plugin(KotlinPlugin())
+    .build()

--- a/juju-core/src/testFixtures/kotlin/com/juloungjuloung/juju/domain/DomainTestFixtures.kt
+++ b/juju-core/src/testFixtures/kotlin/com/juloungjuloung/juju/domain/DomainTestFixtures.kt
@@ -1,23 +1,18 @@
-package com.juloungjuloung.juju
+package com.juloungjuloung.juju.domain
 
 import com.juloungjuloung.juju.domain.product.impl.Bracelet
 import com.juloungjuloung.juju.domain.product.impl.Earring
 import com.juloungjuloung.juju.domain.product.impl.Necklace
 import com.juloungjuloung.juju.domain.product.impl.Ring
 import com.juloungjuloung.juju.enums.ProductTypeEnum
-import com.navercorp.fixturemonkey.FixtureMonkey
-import com.navercorp.fixturemonkey.kotlin.KotlinPlugin
+import com.juloungjuloung.juju.fixtureMonkey
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.navercorp.fixturemonkey.kotlin.setExp
 import com.navercorp.fixturemonkey.kotlin.setNotNullExp
 
-val fixtureMonkey: FixtureMonkey = FixtureMonkey.builder()
-    .plugin(KotlinPlugin())
-    .build()
-
 fun braceletFixture(updatable: Boolean = false, id: Long = 0L, isDisplay: Boolean = false): Bracelet {
     return fixtureMonkey.giveMeBuilder<Bracelet>()
-        .setExp(Bracelet::type, ProductTypeEnum.BRACELET)
+        .setExp(Bracelet::productType, ProductTypeEnum.BRACELET)
         .setExp(Bracelet::id, 0L)
         .setExp(Bracelet::price, 10000L)
         .setExp(Bracelet::weightByMilliGram, 10000L)
@@ -37,7 +32,7 @@ fun braceletFixture(updatable: Boolean = false, id: Long = 0L, isDisplay: Boolea
 
 fun earringFixture(updatable: Boolean = false, id: Long = 0L, isDisplay: Boolean = false): Earring {
     return fixtureMonkey.giveMeBuilder<Earring>()
-        .setExp(Earring::type, ProductTypeEnum.EARRING)
+        .setExp(Earring::productType, ProductTypeEnum.EARRING)
         .setExp(Earring::id, 0L)
         .setExp(Earring::price, 10000L)
         .setExp(Earring::weightByMilliGram, 10000L)
@@ -55,7 +50,7 @@ fun earringFixture(updatable: Boolean = false, id: Long = 0L, isDisplay: Boolean
 
 fun necklaceFixture(updatable: Boolean = false, id: Long = 0L, isDisplay: Boolean = false): Necklace {
     return fixtureMonkey.giveMeBuilder<Necklace>()
-        .setExp(Necklace::type, ProductTypeEnum.NECKLACE)
+        .setExp(Necklace::productType, ProductTypeEnum.NECKLACE)
         .setExp(Necklace::id, 0L)
         .setExp(Necklace::price, 10000L)
         .setExp(Necklace::weightByMilliGram, 10000L)
@@ -75,7 +70,7 @@ fun necklaceFixture(updatable: Boolean = false, id: Long = 0L, isDisplay: Boolea
 
 fun ringFixture(updatable: Boolean = false, id: Long = 0L, isDisplay: Boolean = false): Ring {
     return fixtureMonkey.giveMeBuilder<Ring>()
-        .setExp(Ring::type, ProductTypeEnum.RING)
+        .setExp(Ring::productType, ProductTypeEnum.RING)
         .setExp(Ring::id, 0L)
         .setExp(Ring::price, 10000L)
         .setExp(Ring::weightByMilliGram, 10000L)

--- a/juju-core/src/testFixtures/kotlin/com/juloungjuloung/juju/domain/VOTestFixtures.kt
+++ b/juju-core/src/testFixtures/kotlin/com/juloungjuloung/juju/domain/VOTestFixtures.kt
@@ -1,0 +1,20 @@
+package com.juloungjuloung.juju.domain
+
+import com.juloungjuloung.juju.domain.product.vo.SaveProductVO
+import com.juloungjuloung.juju.enums.ProductTypeEnum
+import com.juloungjuloung.juju.fixtureMonkey
+import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.navercorp.fixturemonkey.kotlin.setExp
+import com.navercorp.fixturemonkey.kotlin.setNotNullExp
+
+fun saveRingVO(): SaveProductVO {
+    return fixtureMonkey.giveMeBuilder<SaveProductVO>()
+        .setExp(SaveProductVO::productType, ProductTypeEnum.RING)
+        .setNotNullExp(SaveProductVO::name)
+        .setExp(SaveProductVO::price, 10000L)
+        .setExp(SaveProductVO::weightByMilliGram, 10000L)
+        .setExp(SaveProductVO::isDisplay, true)
+        .setNotNullExp(SaveProductVO::thumbnailImage)
+        .setExp(SaveProductVO::isDiamond, false)
+        .sample()
+}

--- a/juju-support/constant/src/main/kotlin/com/juloungjuloung/juju/enums/ProductImageEnum.kt
+++ b/juju-support/constant/src/main/kotlin/com/juloungjuloung/juju/enums/ProductImageEnum.kt
@@ -1,0 +1,6 @@
+package com.juloungjuloung.juju.enums
+
+enum class ProductImageEnum(val url: String) {
+    // TODO : 실제 유효한 디폴트 이미지 URL로 수정할 것
+    PRODUCT_DEFAULT_IMAGE("https://test.com/test.png")
+}


### PR DESCRIPTION
## 작업내용
- application 패키지에 있는 VO 객체들을 domain 패키지로 이동
  - 패키지간 역참조관계 해소
  - 추후 모듈 분리 시, 문제될 수 있는 부분 삭제
- saveProductRequest에 `thumbnailImage`, `isDisplay` 프로퍼티 추가

## 정리된 상품 저장 시, API 호출 흐름도
- `presigned url 발급 API 호출` > `(프론트) 이미지 저장` > `상품 저장 API` > `상품 이미지 저장 API`
- 즉, 이미지부터 저장소(`S3`)에 저장하고 상품, 상품이미지를 DB에 저장함 (image path에 product id별로 나눌까 했지만, image 나눌 필요 없어보인다는 판단하에 이렇게 정함)