### PR TITLE
[수정] 컨트롤러 메서드 유니크한 이름으로 변경

### DIFF
--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/controller/product/ProductColorController.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/controller/product/ProductColorController.kt
@@ -30,14 +30,14 @@ class ProductColorController(
     }
 
     @PostMapping
-    fun saveAll(
+    fun saveProductColors(
         @RequestBody saveProductColorRequest: SaveProductColorRequest
     ): ApiResponse<List<Long>> {
         return success(productColorService.saveAll(toSaveVO(saveProductColorRequest)))
     }
 
     @DeleteMapping
-    fun deleteAll(
+    fun deleteProductColors(
         @RequestBody deleteProductColorRequest: DeleteProductColorRequest
     ): ApiResponse<Boolean> {
         return success(productColorService.deleteAll(deleteProductColorRequest.productColorIds))

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/controller/product/ProductImageController.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/controller/product/ProductImageController.kt
@@ -35,14 +35,14 @@ class ProductImageController(
     }
 
     @PostMapping
-    fun saveAll(
+    fun saveProductImages(
         @RequestBody saveProductImageRequest: SaveProductImageRequest
     ): ApiResponse<List<Long>> {
         return success(productImageService.saveAll(toSaveVO(saveProductImageRequest)))
     }
 
     @DeleteMapping
-    fun delete(
+    fun deleteProductImages(
         @RequestBody deleteProductImageRequest: DeleteProductImageRequest
     ): ApiResponse<Boolean> {
         return success(productImageService.delete(deleteProductImageRequest.productImageIds))
@@ -54,7 +54,7 @@ class ProductImageController(
     }
 
     @PutMapping("change-primary")
-    fun changePrimaryImage(
+    fun changePrimaryImageOfProduct(
         @RequestBody request: ChangePrimaryProductImageRequest
     ): ApiResponse<Long> {
         return success(productImageService.changePrimary(request.productId, request.primaryProductImageId))

--- a/juju-admin/src/main/kotlin/com/juloungjuloung/juju/controller/product/ProductMaterialController.kt
+++ b/juju-admin/src/main/kotlin/com/juloungjuloung/juju/controller/product/ProductMaterialController.kt
@@ -32,14 +32,14 @@ class ProductMaterialController(
     }
 
     @PostMapping
-    fun saveAll(
+    fun saveProductMaterials(
         @RequestBody saveProductMaterialRequest: SaveProductMaterialRequest
     ): ApiResponse<List<Long>> {
         return success(productMaterialService.saveAll(toSaveVO(saveProductMaterialRequest)))
     }
 
     @DeleteMapping
-    fun deleteAll(
+    fun deleteProductMaterials(
         @RequestBody deleteProductMaterialRequest: DeleteProductMaterialRequest
     ): ApiResponse<Boolean> {
         return success(productMaterialService.deleteAll(deleteProductMaterialRequest.productMaterialIds))


### PR DESCRIPTION
## 작업내용
- 컨트롤러 메서드 유니크한 이름으로 변경
- 이유
  - frontend에서 사용하는 openapi-generator에서 api 호출 메서드를 `operationId`로 생성되는데 같은 이름이라면 `saveAll`, `saveAll1`, `saveAll2` 와 같이 작성된다
  - 그러므로 도메인에 특화되어 있으면서, 유니크한 이름으로 작성해 프론트엔드에서 api call method의 네이밍이 직관적일 수 있도록 수정함
<img width="669" alt="image" src="https://github.com/bohub12/juloungjuloung-server/assets/75842372/0142ab50-5f9a-45f0-9c27-2cdefc6d6d5a">
