### PR TITLE
[리팩터링] 상품 이미지 로직 중 delete 동작의 책임과 역할 분리

### DIFF
--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/application/facade/product/ProductColorServiceFacade.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/application/facade/product/ProductColorServiceFacade.kt
@@ -36,8 +36,8 @@ class ProductColorServiceFacade(
     }
 
     private fun deletePersistedProductColorsExcludeRequest(productId: Long, requestedProductColorIds: List<Long>) {
-        val persistedProductColors = findByProduct(productId).map { it.id }
+        val persistedProductColorIds = findByProduct(productId).map { it.id }
 
-        productColorService.deleteAll(persistedProductColors.filterNot { requestedProductColorIds.contains(it) })
+        productColorService.deleteAll(persistedProductColorIds.filterNot { requestedProductColorIds.contains(it) })
     }
 }

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/application/facade/product/ProductImageServiceFacade.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/application/facade/product/ProductImageServiceFacade.kt
@@ -31,7 +31,7 @@ class ProductImageServiceFacade(
     fun upsertProductImages(upsertProductImageVO: UpsertProductImageVO): List<Long> {
         val productImages = upsertProductImageVO.toDomain().validate()
 
-        deleteUnassociatedProductImages(upsertProductImageVO.productId, productImages.getProductImageIds())
+        deletePersistedProductImagesExcludeRequest(upsertProductImageVO.productId, productImages.getProductImageIds())
 
         if (productImages.containsThumbnail()) {
             productService.changeThumbnailImage(upsertProductImageVO.productId, productImages.getThumbnail().imageUrl)
@@ -40,7 +40,9 @@ class ProductImageServiceFacade(
         return productImageService.upsert(upsertProductImageVO)
     }
 
-    private fun deleteUnassociatedProductImages(productId: Long, associatedProductImageIds: List<Long>) {
-        productImageService.deleteUnassociatedProductImages(productId, associatedProductImageIds)
+    private fun deletePersistedProductImagesExcludeRequest(productId: Long, requestedProductImageIds: List<Long>) {
+        val persistedProductImages = readByProduct(productId).map { it.id }
+
+        productImageService.deleteAll(persistedProductImages.filterNot { requestedProductImageIds.contains(it) })
     }
 }

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/service/ProductImageService.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/service/ProductImageService.kt
@@ -39,9 +39,23 @@ class ProductImageService(
     }
 
     @Transactional
-    fun deleteUnassociatedProductImages(productId: Long, associatedProductImageIds: List<Long>) {
-        val productImageIds = readByProduct(productId).map { it.id }
+    fun deleteAll(productImageIds: List<Long>): Boolean {
+        validateDeleteCondition(productImageIds)
 
-        productImageRepository.deleteAll(productImageIds.filterNot { associatedProductImageIds.contains(it) })
+        productImageRepository.deleteAll(productImageIds)
+        return true
+    }
+
+    private fun validateDeleteCondition(productImageIds: List<Long>) {
+        readByIdsOrException(productImageIds)
+    }
+
+    private fun readByIdsOrException(productImageIds: List<Long>): List<ProductImage> {
+        val productImages = productImageRepository.findByIds(productImageIds)
+        if (productImages.size != productImageIds.size) {
+            throw BusinessLogicException(BAD_REQUEST_ID)
+        }
+
+        return productImages
     }
 }


### PR DESCRIPTION
## 작업내용
- `Service`에서는 관련 도메인에 대한 하나의 동작만을 정의하고, DB에 밀접한 검증로직을 구현해준다. (재사용성 ⬆)
  - `로직 in Service` : 관련된 도메인 하나에 대한 하나의 논리적인 동작만을 다룬다 (재사용성 ⬆).
  - `검증로직 in Service` : DB에 밀접한 검증로직을 구현해둔다.
    - Example> 존재하는 ID 인지 검증, 파라미터의 제약조건 (200자 이하) 등을 체크해준다 
- `ServiceFacade` 에서는 여러 Service를 조합해 사용하고, Service에 넘겨주는 데이터의 전처리를 해주거나 비즈니스적 검증 로직을 구현해둔다.
  - `로직 in ServiceFacade` : 관련된 도메인 하나에 대한 하나의 논리적인 동작만을 다룬다 (재사용성 ⬆). 
    - Example> 상품 이미지의 썸네일을 바꾸면, 상품 엔티티의 썸네일 이미지를 바꿔준다 
  - `검증로직 in ServiceFacade` : 비즈니스 측면의 검증 로직을 구현해둔다. 
    -  Example> 상품 이미지의 썸네일 이미지는 단 1장이여야 한다, 상품이미지는 10장 이하여야한다 등등