### PR TITLE
[기능개발] kotlin 내장함수 require 대신 custom한 require 메서드로 대체

### DIFF
--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/Product.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/Product.kt
@@ -3,6 +3,9 @@ package com.juloungjuloung.juju.domain.product
 import com.juloungjuloung.juju.domain.product.vo.UpdateProductVO
 import com.juloungjuloung.juju.enums.ProductTypeEnum
 import com.juloungjuloung.juju.enums.ProductTypeEnum.BASE
+import com.juloungjuloung.juju.response.ApiResponseCode
+import com.juloungjuloung.juju.utils.require
+import com.juloungjuloung.juju.utils.requireNotNull
 import java.time.LocalDateTime
 
 open class Product(
@@ -24,11 +27,14 @@ open class Product(
     }
 
     private fun requireProperties() {
-        require(price >= 0)
-        require(weightByMilliGram >= 0)
+        require(price >= 0, errorResponseCode = ApiResponseCode.PRODUCT_VALID_PRICE_MIN_ZERO)
+        require(weightByMilliGram >= 0, errorResponseCode = ApiResponseCode.PRODUCT_VALID_WEIGHT_MIN_ZERO)
 
         if (isDisplay) {
-            requireNotNull(thumbnailImage)
+            requireNotNull(
+                thumbnailImage,
+                errorResponseCode = ApiResponseCode.PRODUCT_VALID_THUMBNAIL_NOT_NULL_IF_DISPLAYED
+            )
         }
     }
 

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/ProductImage.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/ProductImage.kt
@@ -1,8 +1,8 @@
 package com.juloungjuloung.juju.domain.product
 
-import com.juloungjuloung.juju.exception.BusinessLogicException
 import com.juloungjuloung.juju.response.ApiResponseCode.PRODUCT_IMAGE_SIZE_EXCEED_MAX
 import com.juloungjuloung.juju.response.ApiResponseCode.PRODUCT_IMAGE_THUMBNAIL_NOT_ONE
+import com.juloungjuloung.juju.utils.require
 import java.time.LocalDateTime
 
 data class ProductImage(
@@ -34,13 +34,11 @@ data class ProductImages(
     }
 
     private fun requireProperties() {
-        if (productImages.size >= 10) {
-            throw BusinessLogicException(PRODUCT_IMAGE_SIZE_EXCEED_MAX)
-        }
-
-        if (productImages.isNotEmpty() && productImages.filter { it.isThumbnail }.size != 1) {
-            throw BusinessLogicException(PRODUCT_IMAGE_THUMBNAIL_NOT_ONE)
-        }
+        require(productImages.size < 10, errorResponseCode = PRODUCT_IMAGE_SIZE_EXCEED_MAX)
+        require(
+            productImages.isEmpty() || productImages.filter { it.isThumbnail }.size == 1,
+            errorResponseCode = PRODUCT_IMAGE_THUMBNAIL_NOT_ONE
+        )
     }
 
     fun containsThumbnail(): Boolean {

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/ProductOption.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/ProductOption.kt
@@ -1,7 +1,7 @@
 package com.juloungjuloung.juju.domain.product
 
-import com.juloungjuloung.juju.exception.BusinessLogicException
 import com.juloungjuloung.juju.response.ApiResponseCode.PRODUCT_OPTION_REQUIRES_AT_LEAST_ONE_OPTION
+import com.juloungjuloung.juju.utils.require
 import java.time.LocalDateTime
 
 data class ProductOption(
@@ -25,9 +25,7 @@ data class ProductOptions(
     }
 
     private fun requireProperties() {
-        if (options.isEmpty()) {
-            throw BusinessLogicException(PRODUCT_OPTION_REQUIRES_AT_LEAST_ONE_OPTION)
-        }
+        require(options.isNotEmpty(), PRODUCT_OPTION_REQUIRES_AT_LEAST_ONE_OPTION)
     }
 
     fun updateProductOptionCategoryId(productOptionCategoryId: Long) {

--- a/juju-support/constant/src/main/kotlin/com/juloungjuloung/juju/response/ApiResponseCode.kt
+++ b/juju-support/constant/src/main/kotlin/com/juloungjuloung/juju/response/ApiResponseCode.kt
@@ -16,17 +16,14 @@ enum class ApiResponseCode(
     INTERNAL_SERVER_ERROR(500, "서버 에러입니다"),
 
     // 1000 [Product]
+    PRODUCT_VALID_PRICE_MIN_ZERO(1000, "상품 가격은 0원 이상이여야 합니다"),
+    PRODUCT_VALID_WEIGHT_MIN_ZERO(1001, "상품 무게는 0mg 이상이여야 합니다"),
+    PRODUCT_VALID_THUMBNAIL_NOT_NULL_IF_DISPLAYED(1002, "상품 전시여부가 활성화되어 있을 땐, 대표이미지가 있어야 합니다"),
 
     // 1100 [Product Image]
     PRODUCT_IMAGE_SIZE_EXCEED_MAX(1100, "상품 이미지의 개수가 10개 미만이여야 합니다"),
-    PRODUCT_IMAGE_THUMBNAIL_NOT_ONE(1101, "상품 기본 이미지 개수가 1개여야 합니다"),
-    PRODUCT_IMAGE_REMOVE_CONDITION_THUMBNAIL(1102, "기본 이미지는 삭제할 수 없습니다"),
-
-    // 1200 [Product Color]
-    PRODUCT_COLOR_DUPLICATE_CODE_IN_SAME_PRODUCT(1200, "한 상품에 대한 적용 가능 색상이 중복되었습니다"),
-
-    // 1300 [Product Material]
-    PRODUCT_MATERIAL_DUPLICATE_CODE_IN_SAME_PRODUCT(1300, "한 상품에 대한 적용 가능 재질이 중복되었습니다"),
+    PRODUCT_IMAGE_THUMBNAIL_NOT_ONE(1101, "상품 대표 이미지 개수가 1개여야 합니다"),
+    PRODUCT_IMAGE_REMOVE_CONDITION_THUMBNAIL(1102, "대표 이미지는 삭제할 수 없습니다. 대표 이미지를 변경 후 삭제해주시기 바랍니다"),
 
     // 1200 [Product Option]
     PRODUCT_OPTION_REQUIRES_AT_LEAST_ONE_OPTION(1200, "옵션 카테고리 안에는 최소 한 개 이상의 옵션이 필요합니다")

--- a/juju-support/constant/src/main/kotlin/com/juloungjuloung/juju/utils/CustomPreconditions.kt
+++ b/juju-support/constant/src/main/kotlin/com/juloungjuloung/juju/utils/CustomPreconditions.kt
@@ -1,0 +1,16 @@
+package com.juloungjuloung.juju.utils
+
+import com.juloungjuloung.juju.exception.BusinessLogicException
+import com.juloungjuloung.juju.response.ApiResponseCode
+
+fun require(value: Boolean, errorResponseCode: ApiResponseCode) {
+    if (!value) {
+        throw BusinessLogicException(errorResponseCode)
+    }
+}
+
+fun <T : Any> requireNotNull(value: T?, errorResponseCode: ApiResponseCode) {
+    if (value == null) {
+        throw BusinessLogicException(errorResponseCode)
+    }
+}


### PR DESCRIPTION
## 작업내용
kotlin 내장함수의 `require(value:Boolean)` 대신 custom하게 정의해둔 `require(value:Boolean, errorResponseCode: ApiResponseCode)`를 만들어 사용

### AS-IS
이렇게되면 Preconditions의 require메서드를 사용하면 무조건 `IllegalStateException`을 throw하게 되고 custome한 exception을 던질 수 없게 된다. 만약 custom한 exception을 던지려면 try-catch로 rethrow 해주는 방법밖엔 없다.
```kotlin
require(price > 0)
```

### TO-BE
require 메서드를 `support모듈`에서 정의함으로써 custom한 exception을 던질 수 있도록 수정하였다
```kotlin
require(price > 0, errorResponseCode = ApiResponseCode.PRODUCT_VALID_PRICE_MIN_ZERO)
```