### PR TITLE
[기능수정] 상품 이미지 등록/수정 시, 대표이미지 삭제 요청이라면 상품 엔티티의 대표 이미지 컬럼 `null` 로 변환 

### DIFF
--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/application/facade/product/ProductImageServiceFacade.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/application/facade/product/ProductImageServiceFacade.kt
@@ -30,12 +30,9 @@ class ProductImageServiceFacade(
     fun upsertProductImages(upsertProductImageVO: UpsertProductImageVO): List<Long> {
         val productImages = upsertProductImageVO.toDomain().validate()
 
+        productService.changeThumbnailImage(upsertProductImageVO.productId, productImages.getThumbnail()?.imageUrl)
+
         deletePersistedProductImagesExcludeRequest(upsertProductImageVO.productId, productImages.getProductImageIds())
-
-        if (productImages.containsThumbnail()) {
-            productService.changeThumbnailImage(upsertProductImageVO.productId, productImages.getThumbnail().imageUrl)
-        }
-
         return productImageService.upsert(upsertProductImageVO)
     }
 

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/Product.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/Product.kt
@@ -54,6 +54,10 @@ open class Product(
     fun changeThumbnailImage(imageUrl: String) {
         this.thumbnailImage = imageUrl
     }
+
+    fun deleteThumbnailImage() {
+        this.thumbnailImage = null
+    }
 }
 
 data class ProductsWithCount(

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/ProductImage.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/ProductImage.kt
@@ -45,8 +45,8 @@ data class ProductImages(
         return productImages.any { it.isThumbnail }
     }
 
-    fun getThumbnail(): ProductImage {
-        return productImages.first { it.isThumbnail }
+    fun getThumbnail(): ProductImage? {
+        return productImages.find { it.isThumbnail }
     }
 
     fun getProductImageIds(): List<Long> {

--- a/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/service/impl/ProductServiceImpl.kt
+++ b/juju-core/src/main/kotlin/com/juloungjuloung/juju/domain/product/service/impl/ProductServiceImpl.kt
@@ -6,6 +6,8 @@ import com.juloungjuloung.juju.domain.product.service.ProductService
 import com.juloungjuloung.juju.domain.product.vo.SaveProductVO
 import com.juloungjuloung.juju.domain.product.vo.UpdateProductVO
 import com.juloungjuloung.juju.enums.ProductTypeEnum
+import com.juloungjuloung.juju.response.ApiResponseCode.PRODUCT_IMAGE_REMOVE_CONDITION_THUMBNAIL
+import com.juloungjuloung.juju.utils.require
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -43,11 +45,18 @@ class ProductServiceImpl(
 
     fun changeThumbnailImage(
         productId: Long,
-        thumbnailImageUrl: String
+        thumbnailImageUrl: String?
     ) {
         val product = readById(productId)
 
-        product.changeThumbnailImage(thumbnailImageUrl)
+        if (thumbnailImageUrl.isNullOrBlank()) {
+            require(!product.isDisplay, PRODUCT_IMAGE_REMOVE_CONDITION_THUMBNAIL)
+
+            product.deleteThumbnailImage()
+        } else {
+            product.changeThumbnailImage(thumbnailImageUrl)
+        }
+
         productRepository.changeThumbnailImage(product)
     }
 }

--- a/juju-core/src/test/kotlin/com/juloungjuloung/juju/domain/product/service/impl/ProductServiceImplTest.kt
+++ b/juju-core/src/test/kotlin/com/juloungjuloung/juju/domain/product/service/impl/ProductServiceImplTest.kt
@@ -1,0 +1,64 @@
+package com.juloungjuloung.juju.domain.product.service.impl
+
+import com.juloungjuloung.juju.domain.product.productFixture
+import com.juloungjuloung.juju.domain.product.repository.ProductRepository
+import com.juloungjuloung.juju.exception.BusinessLogicException
+import com.juloungjuloung.juju.response.ApiResponseCode.PRODUCT_IMAGE_REMOVE_CONDITION_THUMBNAIL
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class ProductServiceImplTest : BehaviorSpec({
+
+    val productRepository = mockk<ProductRepository>(relaxed = true)
+    val sut = ProductServiceImpl(productRepository)
+
+    Given("상품 대표 이미지를 삭제할 때") {
+        val productId = 1L
+
+        When("전시 중인 상품이라면") {
+            val product = productFixture(id = productId, isDisplay = true)
+            every { productRepository.findById(productId) } returns product
+
+            Then("예외 발생") {
+                val exception =
+                    shouldThrow<BusinessLogicException> {
+                        sut.changeThumbnailImage(productId, null)
+                    }
+                exception.code shouldBe PRODUCT_IMAGE_REMOVE_CONDITION_THUMBNAIL
+            }
+        }
+
+        When("전시 중이지 않은 상품이라면") {
+            val product = productFixture(id = productId, isDisplay = false)
+            every { productRepository.findById(productId) } returns product
+
+            sut.changeThumbnailImage(productId, null)
+
+            Then("정상 실행") {
+                product.thumbnailImage shouldBe null
+                verify { productRepository.changeThumbnailImage(product) }
+            }
+        }
+    }
+
+    Given("상품 대표 이미지를 다른 이미지로 변경하려할 때") {
+        val productId = 1L
+        val thumbnailImageUrl = "https://test.com/test.png"
+
+        val product = productFixture(id = productId)
+        every { productRepository.findById(productId) } returns product
+
+        When("상품 대표 이미지를 변경하면") {
+            sut.changeThumbnailImage(productId, thumbnailImageUrl)
+
+            Then("정상 실행") {
+                product.thumbnailImage shouldBe thumbnailImageUrl
+                verify { productRepository.changeThumbnailImage(product) }
+            }
+        }
+    }
+})

--- a/juju-support/constant/src/main/kotlin/com/juloungjuloung/juju/response/ApiResponseCode.kt
+++ b/juju-support/constant/src/main/kotlin/com/juloungjuloung/juju/response/ApiResponseCode.kt
@@ -20,7 +20,10 @@ enum class ApiResponseCode(
     // 1100 [Product Image]
     PRODUCT_IMAGE_SIZE_EXCEED_MAX(1100, "상품 이미지의 개수가 10개 미만이여야 합니다"),
     PRODUCT_IMAGE_THUMBNAIL_NOT_ONE(1101, "상품 대표 이미지 개수가 1개여야 합니다"),
-    PRODUCT_IMAGE_REMOVE_CONDITION_THUMBNAIL(1102, "대표 이미지는 삭제할 수 없습니다. 대표 이미지를 변경 후 삭제해주시기 바랍니다"),
+    PRODUCT_IMAGE_REMOVE_CONDITION_THUMBNAIL(
+        1102,
+        "상품이 전시 중일 때에는 대표 이미지는 삭제할 수 없습니다. 상품 전시여부를 수정하시거나 대표 이미지를 변경하신 후 삭제해주시기 바랍니다"
+    ),
 
     // 1200 [Product Option]
     PRODUCT_OPTION_REQUIRES_AT_LEAST_ONE_OPTION(1200, "옵션 카테고리에 최소 한 개 이상의 옵션이 필요합니다")


### PR DESCRIPTION
## 작업내용
- 상품 대표 이미지 삭제 시, 상품 엔티티의 대표 이미지 `null`로 변환
  - 전시 중인 상품일 경우, 예외 발생
- 관련 테스트코드 작성